### PR TITLE
Add scoped property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@ Supports the [Highlight.js options](http://highlightjs.readthedocs.org/en/latest
 * `classPrefix`
 * `languages`
 
+You can also customise which blocks of code you would like to highlight by passing `scoped` and a `querySelector` of your choice.
+
+```js
+var Metalsmith = require('metalsmith'),
+    highlight  = require('metalsmith-code-highlight');
+
+Metalsmith(__dirname)
+    .use(highlight({
+        scoped: 'pre code'
+    }))
+    .build();
+```
+
+This option defaults to `code`.
+
 ## Alternatives
 
 * [metalsmith-metallic](https://github.com/weswigham/metalsmith-metallic): Highlights only within Markdown

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-var domino = require('domino'),
+var assign = require('object-assign'),
+    domino = require('domino'),
     highlight = require('highlight.js');
 
 var window, document, container;
@@ -27,7 +28,7 @@ var getLanguage = function(element) {
  * @param {!string} html
  * @return {!string} New HTML with code highlighted
  */
-var highlightFile = function(html) {
+var highlightFile = function(html, scoped) {
   var i, len, codeBlocks, codeBlock, lang, result;
 
   // Parse HTML into DOM
@@ -37,7 +38,7 @@ var highlightFile = function(html) {
 
   container.innerHTML = html;
 
-  codeBlocks = container.querySelectorAll('code');
+  codeBlocks = container.querySelectorAll(scoped);
   for(i = 0, len = codeBlocks.length; i < len; i++) {
     codeBlock = codeBlocks[i];
     lang = getLanguage(codeBlock);
@@ -61,6 +62,10 @@ var highlightFile = function(html) {
 module.exports = function(options) {
   highlight.configure(options);
 
+  options = assign({
+    scoped: 'code'
+  }, options || {});
+
   /**
    * @param {Object} files
    * @param {Metalsmith} metalsmith
@@ -72,7 +77,7 @@ module.exports = function(options) {
       if (HTML_FILENAME_REGEXP.test(file)) {
         data = files[file];
         data.contents = new Buffer(
-          highlightFile(data.contents.toString())
+          highlightFile(data.contents.toString(), options.scoped)
         );
       }
     }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/fortes/metalsmith-code-highlight",
   "dependencies": {
     "domino": "^1.0.18",
-    "highlight.js": "^8.2.0"
+    "highlight.js": "^8.2.0",
+    "object-assign": "^2.0.0"
   }
 }


### PR DESCRIPTION
This change allows consumers to limit highlighting to certain elements, if they wish. I was having a couple of problems with this trying to highlight path names in inline code blocks.

I couldn't get the tests to pass before introducing this change, so it is untested.

```
$ npm test

> metalsmith-code-highlight@0.0.2 test /Users/bbriggs/projects/metalsmith-code-highlight
> node test.js


assert.js:92
  throw new assert.AssertionError({
        ^
AssertionError: "<p>Hello there.</p><p>Inline <code class=\"lang-js\"><span class=\"hljs-built_in\">document</span>.all</code></p><pre><code cla == "<p>Hello there.</p><p>Inline <code class=\"lang-js\"><span class=\"hljs-built_in\">document</span>.all</code></p><pre><code cla
    at Object._onImmediate (/Users/bbriggs/projects/metalsmith-code-highlight/test.js:39:10)
    at processImmediate [as _immediateCallback] (timers.js:345:15)
npm ERR! Test failed.  See above for more details.
```
