### PR TITLE
Implement 'selector' option to override 'code' as default selector.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Supports the [Highlight.js options](http://highlightjs.readthedocs.org/en/latest
 
 If you'd like to turn off automatic language detection, set `{languages: []}`. Only code blocks marked with an appropriate `class` like `lang-js` will be highlighted (useful when using [fenced code blocks](https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting) in Markdown).
 
+By default, this plugin will highlight all `code` elements. You can override the selector for what to highlight by passing in a `selector` option like so: `{selector: 'pre > code'}`. This will only highlight `<pre>`'s immediate `<code>` children elements. This is a metalsmith-code-highlight specific option—it isn't part of highlight.js.
+
 ## Using with `metalsmith-dom-transform`
 
 If you're already using [`metalsmith-dom-transform`](https://github.com/fortes/metalsmith-dom-transform), you can save a little bit of overhead by accessing the code highlight transform directly:
@@ -60,6 +62,7 @@ metalsmith.use(domTransform({
 
 ## Changelog
 
+* `1.1.0`: Allow a `selector` option for overriding the default selector of `code`.
 * `1.0.3`: Upgrade to `metalsmith-dom-transform` `2.0.0`, no functional changes
 * `1.0.2`: Upgrade to `metalsmith-dom-transform` `1.0.1`, may cause slight change in HTML output when there is no content to highlight
 * `1.0.1`: Use `highlightBlock` from `highlight.js` for the highlighting, slight change in HTML output

--- a/__snapshots__/transform.test.js.snap
+++ b/__snapshots__/transform.test.js.snap
@@ -11,4 +11,11 @@ exports[`highlights multiple <code> blocks 1`] = `
 <code class=\\"highlighted\\">Naked code block</code></main>"
 `;
 
+exports[`highlights via custom selector 1`] = `
+"<main><h1>Non-code text</h1>
+<p>P with <code>inline</code> code.</p>
+<pre class=\\"lang-highlight\\"><code class=\\"highlighted\\">Code Block Within pre</code></pre>
+<code>Naked code block</code></main>"
+`;
+
 exports[`via domTransform runs 1`] = `"<p class=\\"lang-highlight\\">Hello <code class=\\"highlighted\\">code</code></p>"`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-code-highlight",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Metalsmith plugin for adding syntax highlighting to code within posts",
   "main": "index.js",
   "scripts": {

--- a/transform.js
+++ b/transform.js
@@ -1,10 +1,13 @@
 const highlight = require('highlight.js');
+const defaults = {selector: 'code'};
 
 module.exports = function(options) {
   highlight.configure(options);
+  let normalizedOptions = Object.assign({}, defaults, options);
+  let {selector} = normalizedOptions;
 
   return function highlightContent(root, data, metalsmith, done) {
-    Array.from(root.querySelectorAll('code')).forEach(node => {
+    Array.from(root.querySelectorAll(selector)).forEach(node => {
       highlight.highlightBlock(node);
 
       // Tag the parent node as well for style adjustments

--- a/transform.test.js
+++ b/transform.test.js
@@ -56,6 +56,19 @@ describe('highlights', () => {
       expect(root.outerHTML).toMatchSnapshot();
     });
   });
+
+  test('via custom selector', () => {
+    let transformer = promisify(transform({selector: 'pre > code'}));
+    root.innerHTML = `<h1>Non-code text</h1>
+<p>P with <code>inline</code> code.</p>
+<pre><code>Code Block Within pre</code></pre>
+<code>Naked code block</code>`;
+
+    return transformer(root, {}, {}).then(() => {
+      expect(highlight.highlightBlock).toHaveBeenCalledTimes(1);
+      expect(root.outerHTML).toMatchSnapshot();
+    });
+  });
 });
 
 describe('via domTransform', () => {


### PR DESCRIPTION
Test added in transform.test.js and README updated.
Suggesting version change to 1.1.0

Please let me know if there's more work needed.